### PR TITLE
Add non-gui mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,10 @@ project(crowd VERSION 1.0.0)
 find_package (Qt5 COMPONENTS Core Gui Widgets REQUIRED)
 
 enable_language (CXX)
-set (CMAKE_CXX_STANDARD 11)
 
+set (CMAKE_CXX_STANDARD 11)
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -W -Wall -Wextra -pedantic")
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config/config.json ${CMAKE_CURRENT_BINARY_DIR}/src/config.json COPYONLY)
 
 add_subdirectory (src)

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -31,7 +31,7 @@ Engine::Engine()
     connect(m_timer.get(),  &QTimer::timeout, this, [this]{ this->update(); });
     connect(m_objects_pool.get(), &ObjectsPool::endOfSimulation, this, &Engine::finishSimulation);
 
-    m_timer->setInterval(m_timerTick);
+    m_timer->setInterval(m_simulationDelay);
 
     m_stat_thread.reset(new QThread());
     m_stat.reset(new Statistics());
@@ -59,11 +59,11 @@ void Engine::update(bool isTimeRun)
         m_mousePrevPos = QCursor::pos();
     }
 
-    if (isTimeRun && !m_isMouseMove )
+    if (isTimeRun && !m_isMouseMove)
     {
-        m_simulationTime += m_timerTick;
+        m_simulationTime += m_simulationStep;
         //QTime start = QTime::currentTime();
-        this->m_calculator->update(m_timerTick);
+        this->m_calculator->update(m_simulationStep);
         //qDebug() << "calc update elapsed:" << start.elapsed();
     }
 
@@ -85,7 +85,7 @@ void Engine::pause()
 void Engine::resume()
 {
     m_stat->reset();
-    m_timer->setInterval(m_timerTick);
+    m_timer->setInterval(m_simulationDelay);
     emit startSimulation(0);
     m_timer->start();
 }

--- a/src/engine.h
+++ b/src/engine.h
@@ -26,13 +26,15 @@ public:
 
     void setCollectStat(bool collectStat = true) { m_calculator->setCollectStat(collectStat); }
 
-    void setTimerTick(double tick) { m_timerTick = tick; }
+    void setSimulationStep(double step) { m_simulationStep = step; }
+
+    void setDelay(double delay) { m_simulationDelay = delay; }
 
     bool isStarted() const { return m_timer->isActive(); }
 
     int getSimulationTime() const { return m_simulationTime; }
 
-    int getTimerTick() const { return m_timerTick; }
+    int getTimerTick() const { return m_simulationStep; }
 
     QString getPlanFilePath() const { return m_lastPlanFilePath; }
 
@@ -58,7 +60,6 @@ signals:
     void tick();
     void enableStatButton();
     void startSimulation(int n);
-
     void sendStatReportSignal(QString report);
     void changeScaleSignal(double scale);
     void updateAgentInRoomSignal(int num);
@@ -75,7 +76,8 @@ public slots:
     void startSimulationSlot();
 
 private:
-    int m_timerTick = 100; // milliseconds
+    int m_simulationStep = 100; // milliseconds
+    int m_simulationDelay = 100; // milliseconds
     int m_simulationTime = 0;
 
     bool m_isMouseMove = false;

--- a/src/json_manager.cpp
+++ b/src/json_manager.cpp
@@ -4,7 +4,7 @@
 #include <QTextStream>
 #include <QJsonDocument>
 
-QString JsonManager::m_confPath("config/config.json");
+QString JsonManager::m_confPath("config.json");
 
 JsonManager::JsonManager()
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,17 +1,47 @@
 #include "mainwindow.h"
 #include <QApplication>
+#include <QCoreApplication>
 
 #include <memory>
 
 #include "engine.h"
 #include "agent.h"
+#include "non_gui.h"
+
+QCoreApplication* createApplication(int &argc, char *argv[])
+{
+    if (argc > 1)
+        return new QCoreApplication(argc, argv);
+
+    return new QApplication(argc, argv);
+}
 
 int main(int argc, char *argv[])
 {
-    QApplication a(argc, argv);
+    std::unique_ptr<QCoreApplication> a(createApplication(argc, argv));
+    std::unique_ptr<MainWindow> w;
+    std::unique_ptr<NonGuiRunner> runner;
 
-    MainWindow w;
-    w.show();
+    if (argc == 1)
+    {
+        w.reset(new MainWindow());
+        w->show();
+    }
+    else if (argc == 5)
+    {
+        // ./crowd <conf> <scheme> <panic>[0 - 1] <algo>[0 - none, 1 - A*, 2 - Lee]
+        QString conf(argv[1]);
+        QString scheme(argv[2]);
+        double panic = QString(argv[3]).toDouble();
+        int algo = QString(argv[4]).toInt();
 
-    return a.exec();
+        runner.reset(new NonGuiRunner(conf, scheme, panic, algo));
+    }
+    else
+    {
+        qDebug() << "Bad argument list.";
+        QCoreApplication::exit();
+    }
+
+    return a->exec();
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -92,9 +92,7 @@ void MainWindow::updateStatSlot(QString report)
 
 void MainWindow::on_change_crowd_params_triggered()
 {
-    QJsonObject curParam = JsonManager::parseJsonFile(m_configPath);
-
-    m_crowdParameters.reset(new CrowdParameters(curParam));
+    m_crowdParameters.reset(new CrowdParameters(JsonManager::parseJsonFile(JsonManager::getConfPath())));
     m_crowdParameters->show();
 }
 
@@ -162,7 +160,7 @@ void MainWindow::on_checkBox_2_clicked(bool checked)
 
 void MainWindow::on_doubleSpinBox_valueChanged(double arg1)
 {
-    m_engine->setTimerTick(arg1);
+    m_engine->setSimulationStep(arg1);
 }
 
 void MainWindow::on_pathfindingCheckBox_clicked(bool checked)

--- a/src/non_gui.h
+++ b/src/non_gui.h
@@ -1,0 +1,52 @@
+#ifndef NON_GUI_H
+#define NON_GUI_H
+
+#include <QObject>
+#include <QCoreApplication>
+
+#include "json_manager.h"
+
+class NonGuiRunner : public QObject
+{
+    Q_OBJECT
+
+public:
+    NonGuiRunner(const QString& conf, const QString& scheme, double panic, int algo)
+    {
+        m_engine.reset(new Engine());
+
+        JsonManager::setConfPath(conf);
+
+        m_engine->loadPlan(scheme);
+        m_engine->getCalculator().changePanicLevelSlot(panic);
+
+        if (!algo)
+            m_engine->getCalculator().setUsePathFinding(false);
+        else
+            m_engine->getCalculator().pathAlgorithmChangedSlot(algo - 1);
+
+        m_engine->setDelay(0);
+        m_engine->resume();
+
+        connect(m_engine.get(), &Engine::sendStatReportSignal, this, &NonGuiRunner::simulationFinishSlot);
+        //connect(m_engine.get(), &Engine::updateAgentInRoomSignal, this, &NonGuiRunner::updateAgentsInRoomSlot);
+    }
+
+public slots:
+    void simulationFinishSlot(QString report)
+    {
+        qDebug() << "Result:\n" << report;
+        QCoreApplication::exit();
+    }
+
+//    void updateAgentsInRoomSlot(int n)
+//    {
+//        qDebug() << n;
+//    }
+
+private:
+    std::unique_ptr<Engine> m_engine;
+};
+
+#endif // NON_GUI_H
+


### PR DESCRIPTION
Issue #1 
Output to stdout. A lot of debug info in output for now, but it works. No slowing down for visualization, using full CPU power, much faster then visual mode. Simulation end condition - all agents are out, it will be forever, if someone is blocked) It won't work for schemes with entries.
Usage: `./crowd <conf> <scheme> <panic>[0 - 1] <algo>[0 - none, 1 - A*, 2 - Lee]`